### PR TITLE
Fix latitude units in Hargreaves PET

### DIFF
--- a/src/dhbv2/pet.py
+++ b/src/dhbv2/pet.py
@@ -24,7 +24,7 @@ def hargreaves_pet(
     tmean
         Mean daily temperature [degC]
     lat
-        Latitude [deg]
+        Latitude [rad]
     day_of_year
         Day of the year (1-365/366)
 


### PR DESCRIPTION
## Issue Addressed

<!-- Give a brief ~1 sentence overview of the main addition proposed by this pull request.
--> hargreaves_pet function input units for latitude should be in radians not degrees

## Description

<!-- Describe how you addressed the bug/feature request, what choices you made and why. Changes can be listed as bullet point;

- ...
- ...

--> hargreaves_pet function input units for latitude should be in radians not degrees

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactor
- [ ] Documentation update

Other (please specify):

## Checklist

- [ ] Branch is up to date with master
- [ ] Updated tests or added new tests
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation (if applicable)
- [x] Code follows established style and conventions
